### PR TITLE
refactor: rename variable for better clarity in delete_poll function

### DIFF
--- a/app/api/danger.py
+++ b/app/api/danger.py
@@ -8,9 +8,9 @@ router = APIRouter()
 
 @router.delete("/{poll_id}")
 def delete_poll(poll_id: UUID):
-    poll = utils.get_poll(poll_id=poll_id)
-    poll_title = poll.title
-    if not poll:
+    poll_to_delete = utils.get_poll(poll_id=poll_id)
+    poll_title = poll_to_delete.title
+    if not poll_to_delete:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="A poll by that ID does ot exist"


### PR DESCRIPTION
This PR addresses issue #1 by renaming the variable from `poll` to `poll_to_delete` in the `delete_poll` function for better code clarity.

## Changes
- Renamed variable from `poll` to `poll_to_delete` in `app/api/danger.py`
- Updated all references to use the new variable name

Closes #1

Generated with [Claude Code](https://claude.ai/code)